### PR TITLE
Fix Reverse Message Functionality

### DIFF
--- a/app/src/main/java/com/enixcoda/smsforward/SMSReceiver.java
+++ b/app/src/main/java/com/enixcoda/smsforward/SMSReceiver.java
@@ -41,7 +41,7 @@ public class SMSReceiver extends BroadcastReceiver {
             if (senderNumber.equals(targetNumber)) {
                 // reverse message
                 String formatRegex = "To (\\+?\\d+?):\\n((.|\\n)*)";
-                if (rawMessageContent.equals(formatRegex)) {
+                if (rawMessageContent.matches(formatRegex)) {
                     String forwardNumber = rawMessageContent.replaceFirst(formatRegex, "$1");
                     String forwardContent = rawMessageContent.replaceFirst(formatRegex, "$2");
                     Forwarder.sendSMS(forwardNumber, forwardContent);


### PR DESCRIPTION
The option to reverse send a message by sending a message from the target number wasn't working because the code used the '.equals()' method when checking if the received text matched the specified regex for that functionality. This is fixed by using the '.matches()' method instead.